### PR TITLE
fix 'enc_dictionary already defined' error

### DIFF
--- a/src/firetunnel/firetunnel.h
+++ b/src/firetunnel/firetunnel.h
@@ -387,7 +387,6 @@ void print_timestamp(void);
 int blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
 
 // secret.c
-uint8_t enc_dictionary[KEY_LEN * KEY_MAX];
 void init_keys(uint16_t port);
 uint8_t *get_hash(uint8_t *in, unsigned inlen, uint32_t timestamp, uint32_t seq);
 


### PR DESCRIPTION
See https://github.com/netblue30/firetunnel/issues/2 for details on the errors.
This _does fix_ the build issues reported in #2, but as I'm not an expert in security it's strongly advised to double-check whether this patch keeps firetunnel working as expected.